### PR TITLE
Use specified IP address for sending WoL packet; Podman building support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Makefile
+Dockerfile
+.dockerignore
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:1.23 AS server_builder
+FROM docker.io/library/golang:1.23 AS server_builder
 WORKDIR /app
 COPY ./apps/server /app
 RUN CGO_ENABLED=0 GOOS=linux go build -o server main.go
 
 
-FROM oven/bun:1 AS web_builder
+FROM docker.io/oven/bun:1 AS web_builder
 WORKDIR /app
 COPY . .
 RUN bun install
 RUN bun run build
 
 
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 # FROM ubuntu:latest
 WORKDIR /app
 COPY --from=server_builder /app/server ./server

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+IMAGE_NAME ?= huakunshen/wol:latest
 buildx:
 	docker buildx build --push \
 		--platform linux/arm64,linux/amd64 \
-		-t huakunshen/wol:latest .
+		-t $(IMAGE_NAME) .
 
+buildx-podman:
+	podman buildx build --jobs=2 --platform=linux/arm64,linux/amd64 --manifest=$(IMAGE_NAME) .;  \
+	podman manifest push $(IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE_NAME ?= huakunshen/wol:latest
+.phony: buildx buildx-podman
 buildx:
 	docker buildx build --push \
 		--platform linux/arm64,linux/amd64 \

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -69,7 +69,8 @@ func main() {
 			if !ok {
 				return e.JSON(400, map[string]string{"message": "Failed to parse port"})
 			}
-			err = wol.WakeOnLan(mac, "255.255.255.255", strconv.Itoa(port))
+                        targetIp:= requestedHost.GetString("ip")
+			err = wol.WakeOnLan(mac, targetIp, strconv.Itoa(port))
 			if err != nil {
 				return e.JSON(400, map[string]string{"message": "Failed to wake host", "error": err.Error()})
 			}


### PR DESCRIPTION
1. The original implementation always sends WoL packet to `255.255.255.255`, which may not be satisfying if the sender is connected to many interfaces. I changed it to send WoL packet to the user-specified IP (which seems to be unused in the code).
    - In fact, sending WoL to `255.255.255.255` does not work on my network; `tcpdump` captures nothing.
    - A bit [investigation](https://serverfault.com/questions/347886/255-255-255-255-broadcast-address-meaning) tells me it seems that `255.255.255.255` only points to the first interface in kernel route table, if not binding an laddr in [net.DialUDP](https://pkg.go.dev/net#DialUDP) .
    - TODO: it should be documented that the IP specified by user should (better) be a local broadcast IP (one like `192.168.10.255`)?
    - TODO: **THIS CHANGE MAY BE BREAKING** if the original IP field is used as description text. Maybe switch to an optional field?
2. Added support for building the image using [Podman](https://podman.io/):
    - (My motivation: It is much easier to use an HTTP proxy with Podman)
    - Podman prefers fully-qualified image names (the ones started with `docker.io/library`),therefore Dockerfile is modified.
    - Added `buildx-podman` target in Makefile, building and pushing the Docker image using podman manifest.